### PR TITLE
Bug 24 Fix so that GitRunner waits for the processes to finish.

### DIFF
--- a/src/main/java/acime/GitRunner.java
+++ b/src/main/java/acime/GitRunner.java
@@ -31,6 +31,12 @@ public class GitRunner {
         Path tempDir = Files.createTempDirectory(null);
         String cmd = "git clone " + clone_url;
         Process p = this.rfac.makeRuntime().exec(cmd, null, tempDir.toFile());
+	try {
+	    p.waitFor();
+	}
+	catch(InterruptedException e) {
+
+	}
         tempDir.toFile().deleteOnExit();
         return tempDir.toFile();
     }
@@ -45,6 +51,12 @@ public class GitRunner {
         String cmd = "git checkout " + commit_hash;
         File repository = new File(repoDir.getPath()+"/"+repoDir.list()[0]);
         Process p = this.rfac.makeRuntime().exec(cmd, null, repository);
+	try {
+	    p.waitFor();
+	}
+	catch(InterruptedException e) {
+
+	}
     }
 
     /**
@@ -56,6 +68,12 @@ public class GitRunner {
     public boolean isValidGitRepo(String clone_url) throws IOException {
         String cmd = "git ls-remote  " + clone_url;
         Process p = this.rfac.makeRuntime().exec(cmd, null, new File(System.getProperty("user.dir")));
+	try {
+	    p.waitFor();
+	}
+	catch(InterruptedException e) {
+
+	}
         BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
         String output = stdout.lines().collect(Collectors.joining(System.lineSeparator()));
         return !output.isEmpty();

--- a/src/test/java/acime/GitRunnerTest.java
+++ b/src/test/java/acime/GitRunnerTest.java
@@ -21,7 +21,6 @@ public class GitRunnerTest {
 	    GitRunner gr = new GitRunner(new BasicRuntimeFactory());
 	    File repoDir = gr.cloneRepo("https://github.com/jsjolen/smallest-java-ci.git");
         File repoContainer = new File(repoDir.getPath() + "/smallest-java-ci");
-        Thread.sleep(1000);
         Assertions.assertEquals(true, repoDir.isDirectory());
         Assertions.assertEquals(true, repoContainer.isDirectory());
         repoDir.delete();
@@ -37,7 +36,6 @@ public class GitRunnerTest {
     public void testCheckout() throws IOException, InterruptedException {
         GitRunner gr = new GitRunner(new BasicRuntimeFactory());
         File repoDir = gr.cloneRepo("https://github.com/jsjolen/smallest-java-ci.git");
-        Thread.sleep(2000);
         gr.checkoutCommit(repoDir, "1491e8e189592d6ac7188dde490b2171a9221f29");
         File repoContainer = new File(repoDir.getPath() + "/smallest-java-ci/src/main/java/acime");
         String[] repoFileNames= {"ContinuousIntegrationServer.java"};
@@ -67,5 +65,4 @@ public class GitRunnerTest {
         GitRunner gr = new GitRunner(new BasicRuntimeFactory());
         Assertions.assertEquals(false, gr.isValidGitRepo("This is an invalid repository URL."));
     }
-
 }


### PR DESCRIPTION
Fixes #24 

The bug is that we can't Thread.sleep(), we need to actually wait for the processes to finish (using Process#waitFor()).